### PR TITLE
0.16 dispaly bug fix

### DIFF
--- a/template/index.html
+++ b/template/index.html
@@ -2,6 +2,8 @@
 <html>
 <head>
   <title>Vuetify Parallax Starter</title>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link href='https://fonts.googleapis.com/css?family=Roboto:300,400,500,700|Material+Icons' rel="stylesheet">
   <link href="https://unpkg.com/vuetify/dist/vuetify.min.css" rel="stylesheet">
 </head>
@@ -22,7 +24,7 @@
               class="white--text"
             >
               <img src="assets/vuetify.png" alt="Vuetify.js">
-              <h1 class="white--text mb-2 display-3">Parallax Template</h1>
+              <h1 class="white--text mb-2 display-3 text-xs-center">Parallax Template</h1>
               <div class="headline mb-3 text-xs-center">Powered by Vuetify</div>
               <v-btn
                 class="blue lighten-2 mt-5"
@@ -108,7 +110,7 @@
         <section>
           <v-parallax src="assets/section.jpeg" height="380">
             <v-layout column align-center justify-center>
-              <div class="headline white--text mb-3">Web development has never been easier</div>
+              <div class="headline white--text mb-3 text-xs-center">Web development has never been easier</div>
               <em>Kick-start your application today</em>
               <v-btn
                 class="blue lighten-2 mt-5"

--- a/template/index.html
+++ b/template/index.html
@@ -23,9 +23,9 @@
               justify-center
               class="white--text"
             >
-              <img src="assets/vuetify.png" alt="Vuetify.js">
-              <h1 class="white--text mb-2 display-3 text-xs-center">Parallax Template</h1>
-              <div class="headline mb-3 text-xs-center">Powered by Vuetify</div>
+              <img src="assets/vuetify.png" alt="Vuetify.js" height="200">
+              <h1 class="white--text mb-2 display-1 text-xs-center">Parallax Template</h1>
+              <div class="subheading mb-3 text-xs-center">Powered by Vuetify</div>
               <v-btn
                 class="blue lighten-2 mt-5"
                 dark

--- a/template/index.html
+++ b/template/index.html
@@ -12,182 +12,184 @@
       <v-toolbar-title v-text="title"></v-toolbar-title>
     </v-toolbar>
     <main>
-      <section>
-        <v-parallax src="assets/hero.jpeg" height="600">
+      <v-content>
+        <section>
+          <v-parallax src="assets/hero.jpeg" height="600">
+            <v-layout
+              column
+              align-center
+              justify-center
+              class="white--text"
+            >
+              <img src="assets/vuetify.png" alt="Vuetify.js">
+              <h1 class="white--text mb-2 display-3">Parallax Template</h1>
+              <div class="headline mb-3 text-xs-center">Powered by Vuetify</div>
+              <v-btn
+                class="blue lighten-2 mt-5"
+                dark
+                large
+                href="/pre-made-themes"
+              >
+                Get Started
+              </v-btn>
+            </v-layout>
+          </v-parallax>
+        </section>
+
+        <section>
           <v-layout
             column
+            wrap
+            class="my-5"
             align-center
-            justify-center
-            class="white--text"
           >
-            <img src="assets/vuetify.png" alt="Vuetify.js">
-            <h1 class="white--text mb-2 display-3">Parallax Template</h1>
-            <div class="headline mb-3 text-xs-center">Powered by Vuetify</div>
-            <v-btn
-              class="blue lighten-2 mt-5"
-              dark
-              large
-              href="/pre-made-themes"
-            >
-              Get Started
-            </v-btn>
-          </v-layout>
-        </v-parallax>
-      </section>
-
-      <section>
-        <v-layout
-          column
-          wrap
-          class="my-5"
-          align-center
-        >
-          <v-flex xs12 sm4 class="my-3">
-            <div class="text-xs-center">
-              <h2 class="headline">The best way to start developing</h2>
-              <span class="subheading">
-                Cras facilisis mi vitae nunc 
-              </span>
-            </div>
-          </v-flex>
-          <v-flex xs12>
-            <v-container grid-list-xl>
-              <v-layout row wrap align-center>
-                <v-flex xs12 md4>
-                  <v-card class="elevation-0 transparent">
-                    <v-card-text class="text-xs-center">
-                      <v-icon x-large class="blue--text text--lighten-2">color_lens</v-icon>
-                    </v-card-text>
-                    <v-card-title primary-title class="layout justify-center">
-                      <div class="headline text-xs-center">Material Design</div>
-                    </v-card-title>
-                    <v-card-text>
-                      Cras facilisis mi vitae nunc lobortis pharetra. Nulla volutpat tincidunt ornare. 
-                      Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. 
-                      Nullam in aliquet odio. Aliquam eu est vitae tellus bibendum tincidunt. Suspendisse potenti. 
-                    </v-card-text>
-                  </v-card>
-                </v-flex>
-                <v-flex xs12 md4>
-                  <v-card class="elevation-0 transparent">
-                    <v-card-text class="text-xs-center">
-                      <v-icon x-large class="blue--text text--lighten-2">flash_on</v-icon>
-                    </v-card-text>
-                    <v-card-title primary-title class="layout justify-center">
-                      <div class="headline">Fast development</div>
-                    </v-card-title>
-                    <v-card-text>
-                      Cras facilisis mi vitae nunc lobortis pharetra. Nulla volutpat tincidunt ornare. 
-                      Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. 
-                      Nullam in aliquet odio. Aliquam eu est vitae tellus bibendum tincidunt. Suspendisse potenti. 
-                    </v-card-text>
-                  </v-card>
-                </v-flex>
-                <v-flex xs12 md4>
-                  <v-card class="elevation-0 transparent">
-                    <v-card-text class="text-xs-center">
-                      <v-icon x-large class="blue--text text--lighten-2">build</v-icon>
-                    </v-card-text>
-                    <v-card-title primary-title class="layout justify-center">
-                      <div class="headline text-xs-center">Completely Open Sourced</div>
-                    </v-card-title>
-                    <v-card-text>
-                      Cras facilisis mi vitae nunc lobortis pharetra. Nulla volutpat tincidunt ornare. 
-                      Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. 
-                      Nullam in aliquet odio. Aliquam eu est vitae tellus bibendum tincidunt. Suspendisse potenti. 
-                    </v-card-text>
-                  </v-card>
-                </v-flex>
-              </v-layout>
-            </v-container>
-          </v-flex>
-        </v-layout>
-      </section>
-
-      <section>
-        <v-parallax src="assets/section.jpeg" height="380">
-          <v-layout column align-center justify-center>
-            <div class="headline white--text mb-3">Web development has never been easier</div>
-            <em>Kick-start your application today</em>
-            <v-btn
-              class="blue lighten-2 mt-5"
-              dark
-              large
-              href="/pre-made-themes"
-            >
-              Get Started
-            </v-btn>
-          </v-layout>
-        </v-parallax>
-      </section>
-
-      <section>
-        <v-container grid-list-xl>
-          <v-layout row wrap justify-center class="my-5">
-            <v-flex xs12 sm4>
-              <v-card class="elevation-0 transparent">
-                <v-card-title primary-title class="layout justify-center">
-                  <div class="headline">Company info</div>
-                </v-card-title>
-                <v-card-text>
-                  Cras facilisis mi vitae nunc lobortis pharetra. Nulla volutpat tincidunt ornare. 
-                  Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. 
-                  Nullam in aliquet odio. Aliquam eu est vitae tellus bibendum tincidunt. Suspendisse potenti. 
-                </v-card-text>
-              </v-card>
+            <v-flex xs12 sm4 class="my-3">
+              <div class="text-xs-center">
+                <h2 class="headline">The best way to start developing</h2>
+                <span class="subheading">
+                  Cras facilisis mi vitae nunc 
+                </span>
+              </div>
             </v-flex>
-            <v-flex xs12 sm4 offset-sm1>
-              <v-card class="elevation-0 transparent">
-                <v-card-title primary-title class="layout justify-center">
-                  <div class="headline">Contact us</div>
-                </v-card-title>
-                <v-card-text>
-                  Cras facilisis mi vitae nunc lobortis pharetra. Nulla volutpat tincidunt ornare.
-                </v-card-text>
-                <v-list class="transparent">
-                  <v-list-tile>
-                    <v-list-tile-action>
-                      <v-icon class="blue--text text--lighten-2">phone</v-icon>
-                    </v-list-tile-action>
-                    <v-list-tile-content>
-                      <v-list-tile-title>777-867-5309</v-list-tile-title>
-                    </v-list-tile-content>
-                  </v-list-tile>
-                  <v-list-tile>
-                    <v-list-tile-action>
-                      <v-icon class="blue--text text--lighten-2">place</v-icon>
-                    </v-list-tile-action>
-                    <v-list-tile-content>
-                      <v-list-tile-title>Chicago, US</v-list-tile-title>
-                    </v-list-tile-content>
-                  </v-list-tile>
-                  <v-list-tile>
-                    <v-list-tile-action>
-                      <v-icon class="blue--text text--lighten-2">email</v-icon>
-                    </v-list-tile-action>
-                    <v-list-tile-content>
-                      <v-list-tile-title>john@vuetifyjs.com</v-list-tile-title>
-                    </v-list-tile-content>
-                  </v-list-tile>
-                </v-list>
-              </v-card>
+            <v-flex xs12>
+              <v-container grid-list-xl>
+                <v-layout row wrap align-center>
+                  <v-flex xs12 md4>
+                    <v-card class="elevation-0 transparent">
+                      <v-card-text class="text-xs-center">
+                        <v-icon x-large class="blue--text text--lighten-2">color_lens</v-icon>
+                      </v-card-text>
+                      <v-card-title primary-title class="layout justify-center">
+                        <div class="headline text-xs-center">Material Design</div>
+                      </v-card-title>
+                      <v-card-text>
+                        Cras facilisis mi vitae nunc lobortis pharetra. Nulla volutpat tincidunt ornare. 
+                        Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. 
+                        Nullam in aliquet odio. Aliquam eu est vitae tellus bibendum tincidunt. Suspendisse potenti. 
+                      </v-card-text>
+                    </v-card>
+                  </v-flex>
+                  <v-flex xs12 md4>
+                    <v-card class="elevation-0 transparent">
+                      <v-card-text class="text-xs-center">
+                        <v-icon x-large class="blue--text text--lighten-2">flash_on</v-icon>
+                      </v-card-text>
+                      <v-card-title primary-title class="layout justify-center">
+                        <div class="headline">Fast development</div>
+                      </v-card-title>
+                      <v-card-text>
+                        Cras facilisis mi vitae nunc lobortis pharetra. Nulla volutpat tincidunt ornare. 
+                        Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. 
+                        Nullam in aliquet odio. Aliquam eu est vitae tellus bibendum tincidunt. Suspendisse potenti. 
+                      </v-card-text>
+                    </v-card>
+                  </v-flex>
+                  <v-flex xs12 md4>
+                    <v-card class="elevation-0 transparent">
+                      <v-card-text class="text-xs-center">
+                        <v-icon x-large class="blue--text text--lighten-2">build</v-icon>
+                      </v-card-text>
+                      <v-card-title primary-title class="layout justify-center">
+                        <div class="headline text-xs-center">Completely Open Sourced</div>
+                      </v-card-title>
+                      <v-card-text>
+                        Cras facilisis mi vitae nunc lobortis pharetra. Nulla volutpat tincidunt ornare. 
+                        Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. 
+                        Nullam in aliquet odio. Aliquam eu est vitae tellus bibendum tincidunt. Suspendisse potenti. 
+                      </v-card-text>
+                    </v-card>
+                  </v-flex>
+                </v-layout>
+              </v-container>
             </v-flex>
           </v-layout>
-        </v-container>
-      </section>
+        </section>
 
-      <v-footer class="blue darken-2">
-        <v-layout row wrap align-center>
-          <v-flex xs12>
-            <div class="white--text ml-3">
-              Made with
-              <v-icon class="red--text">favorite</v-icon>
-              by <a class="white--text" href="https://vuetifyjs.com" target="_blank">Vuetify</a>
-              and <a class="white--text" href="mailto:costa.huang@outlook.com">Costa Huang</a>
-            </div>
-          </v-flex>
-        </v-layout>
-      </v-footer>
+        <section>
+          <v-parallax src="assets/section.jpeg" height="380">
+            <v-layout column align-center justify-center>
+              <div class="headline white--text mb-3">Web development has never been easier</div>
+              <em>Kick-start your application today</em>
+              <v-btn
+                class="blue lighten-2 mt-5"
+                dark
+                large
+                href="/pre-made-themes"
+              >
+                Get Started
+              </v-btn>
+            </v-layout>
+          </v-parallax>
+        </section>
+
+        <section>
+          <v-container grid-list-xl>
+            <v-layout row wrap justify-center class="my-5">
+              <v-flex xs12 sm4>
+                <v-card class="elevation-0 transparent">
+                  <v-card-title primary-title class="layout justify-center">
+                    <div class="headline">Company info</div>
+                  </v-card-title>
+                  <v-card-text>
+                    Cras facilisis mi vitae nunc lobortis pharetra. Nulla volutpat tincidunt ornare. 
+                    Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. 
+                    Nullam in aliquet odio. Aliquam eu est vitae tellus bibendum tincidunt. Suspendisse potenti. 
+                  </v-card-text>
+                </v-card>
+              </v-flex>
+              <v-flex xs12 sm4 offset-sm1>
+                <v-card class="elevation-0 transparent">
+                  <v-card-title primary-title class="layout justify-center">
+                    <div class="headline">Contact us</div>
+                  </v-card-title>
+                  <v-card-text>
+                    Cras facilisis mi vitae nunc lobortis pharetra. Nulla volutpat tincidunt ornare.
+                  </v-card-text>
+                  <v-list class="transparent">
+                    <v-list-tile>
+                      <v-list-tile-action>
+                        <v-icon class="blue--text text--lighten-2">phone</v-icon>
+                      </v-list-tile-action>
+                      <v-list-tile-content>
+                        <v-list-tile-title>777-867-5309</v-list-tile-title>
+                      </v-list-tile-content>
+                    </v-list-tile>
+                    <v-list-tile>
+                      <v-list-tile-action>
+                        <v-icon class="blue--text text--lighten-2">place</v-icon>
+                      </v-list-tile-action>
+                      <v-list-tile-content>
+                        <v-list-tile-title>Chicago, US</v-list-tile-title>
+                      </v-list-tile-content>
+                    </v-list-tile>
+                    <v-list-tile>
+                      <v-list-tile-action>
+                        <v-icon class="blue--text text--lighten-2">email</v-icon>
+                      </v-list-tile-action>
+                      <v-list-tile-content>
+                        <v-list-tile-title>john@vuetifyjs.com</v-list-tile-title>
+                      </v-list-tile-content>
+                    </v-list-tile>
+                  </v-list>
+                </v-card>
+              </v-flex>
+            </v-layout>
+          </v-container>
+        </section>
+
+        <v-footer class="blue darken-2">
+          <v-layout row wrap align-center>
+            <v-flex xs12>
+              <div class="white--text ml-3">
+                Made with
+                <v-icon class="red--text">favorite</v-icon>
+                by <a class="white--text" href="https://vuetifyjs.com" target="_blank">Vuetify</a>
+                and <a class="white--text" href="https://github.com/vwxyzjn">Costa Huang</a>
+              </div>
+            </v-flex>
+          </v-layout>
+        </v-footer>
+      </v-content>
     </main>
   </v-app>
  </div>


### PR DESCRIPTION
This branch fixes two problems (and a minor issue):

First, it fixes the current display issues with 0.16, see [Broke?](https://github.com/vuetifyjs/parallax-starter/issues/3) and

![image](https://user-images.githubusercontent.com/5555347/31247213-e235db8c-a9dd-11e7-87dd-2641b76a4702.png)


Second, it fixes the mobile display problem. Previously, the template does not have the following tag

```html
  <meta charset="utf-8">
  <meta name="viewport" content="width=device-width, initial-scale=1.0">
```

and as a result, such theme is not responsive. After adding the tag above and fixing some text centering, we have decent mobile display.

![image](https://user-images.githubusercontent.com/5555347/31247188-d12cfee2-a9dd-11e7-9695-801580b40641.png)

Lastly, I put my github link instead of my email address in the link at the bottom of the page

![image](https://user-images.githubusercontent.com/5555347/31247297-15a10802-a9de-11e7-896f-f6328002cb3d.png)


